### PR TITLE
Set the download client's pool_idle_timeout to 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "quarkdrive-webdav"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quarkdrive-webdav"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2024"
 
 description = "A WebDAV client for quarkdrive"


### PR DESCRIPTION
The server does not support connection reuse when downloading, so set the client's pool_idle_timeout parameter to 0, refer to https://github.com/hyperium/hyper/issues/2136